### PR TITLE
[Schema Builder] [Implementation] Inherit field with subtype

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/TypeCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/TypeCreator.java
@@ -52,11 +52,12 @@ public class TypeCreator extends AbstractCreator {
         for (ClassInfo c = classInfo; c != null; c = ScanningContext.getIndex().getClassByName(c.superName())) {
             if (InterfaceCreator.canAddInterfaceIntoScheme(c.toString())) { // Not java objects
                 List<MethodInfo> classMethods = filterOutBridgeMethod(c.methods());
-                allMethods.addAll(classMethods);
+                // First add interface methods then add class methods, to make sure class methods (return) type overrides
                 allMethods.addAll(getAllInterfaceMethods(c, classMethods
                         .stream()
                         .map(MethodInfo::toString)
                         .collect(Collectors.toSet())));
+                allMethods.addAll(classMethods);
                 for (FieldInfo fieldInfo : c.fields()) {
                     allFields.putIfAbsent(fieldInfo.name(), fieldInfo);
                 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
@@ -186,8 +186,8 @@ public class SchemaBuilderTest {
         Type containerInterface = interfaces.get("ContainerInterface");
         Field containerInterfaceField = containerInterface.getFields().get("inheritField");
 
-        // TODO: Should be FieldType according to GraphQL Spec: https://spec.graphql.org/October2021/#sec-Objects.Type-Validation
-        assertEquals("io.smallrye.graphql.index.inherit.FieldInterface",
+        // Should be FieldType according to GraphQL Spec: https://spec.graphql.org/October2021/#sec-Objects.Type-Validation
+        assertEquals("io.smallrye.graphql.index.inherit.FieldType",
                 containerTypeField.getReference().getClassName());
         assertEquals("io.smallrye.graphql.index.inherit.FieldInterface",
                 containerInterfaceField.getReference().getClassName());


### PR DESCRIPTION
Implementation for #2122 

Before the reordering, the code adds `classMethods` first, `interfaceMethods` then, into the `allMethods` list. However, when looping the `allMethods` list, if `classMethods` and `interfaceMethods` contains an entry with the same name, the latter one will overwrite the previous ones. Therefore, after I reorder them, the `classMethods` will overwrite `interfaceMethods`, thus making "inheriting field with subtype" possible.